### PR TITLE
Replaced use of deprecated textsize with textbbox

### DIFF
--- a/UCTronics_OLED_Display_Python/python/dev_display.py
+++ b/UCTronics_OLED_Display_Python/python/dev_display.py
@@ -182,7 +182,8 @@ def show_network():
     time.sleep(DURATION)
 
 def get_text_center(text, font, center_point):
-    w, h = draw.textsize(text, font=font)
+    left, top, right, bottom = draw.textbbox((0,0), text, font=font)
+    w = right - left
 
     return (center_point -(w/2))
 

--- a/UCTronics_OLED_Display_Python/python/display.py
+++ b/UCTronics_OLED_Display_Python/python/display.py
@@ -182,8 +182,8 @@ def show_network():
     time.sleep(DURATION)
 
 def get_text_center(text, font, center_point):
-    w, h = draw.textsize(text, font=font)
-
+    left, top, right, bottom = draw.textbbox((0,0), text, font=font)
+    w = right - left
     return (center_point -(w/2))
 
 


### PR DESCRIPTION
The current version is broken against the latest version of Pillow.

textsize was removed in version 10.0.0 of Pillow, and the documentation suggests replacing it with textbbox.